### PR TITLE
Recognize more base64 URIs to match Chrome behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,53 @@ PATH
   remote: .
   specs:
     facet_rails_common (0.1.0)
+      order_query (~> 0.5.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (8.0.2.1)
+      activesupport (= 8.0.2.1)
+    activerecord (8.0.2.1)
+      activemodel (= 8.0.2.1)
+      activesupport (= 8.0.2.1)
+      timeout (>= 0.4.0)
+    activesupport (8.0.2.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.3)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
+    drb (2.2.3)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    logger (1.7.0)
+    minitest (5.25.5)
+    order_query (0.5.5)
+      activerecord (>= 5.0, < 8.1)
+      activesupport (>= 5.0, < 8.1)
     rake (13.1.0)
+    securerandom (0.4.1)
+    timeout (0.4.3)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.0.3)
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-24
 
 DEPENDENCIES
   facet_rails_common!

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -23,18 +23,19 @@ class ::DataUri
     header_end = @match.begin(:data)
     header = header_end.nil? ? '' : uri[0...header_end]
     @header_contains_base64 = !!(header.match?(/base64/i))
+    
+    @mimetype = String(@match[:mimetype]).empty? ? 'text/plain' : @match[:mimetype]
+    @parameters = String(@match[:parameters]).split(';').reject(&:empty?)
+    @extension = @match[:extension]
+    @data = @match[:data]
+    
+    validate_base64_content
 
     if uri.start_with?('data:,')
       @mimetype = 'text/plain'
       @parameters = []
       @extension = nil
       @data = uri.split(',', 2).last || ''
-    else
-      @mimetype = String(@match[:mimetype]).empty? ? 'text/plain' : @match[:mimetype]
-      @parameters = String(@match[:parameters]).split(';').reject(&:empty?)
-      @extension = @match[:extension]
-      @data = @match[:data]
-      validate_base64_content
     end
   end
 

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -107,6 +107,6 @@ class ::DataUri
     header_end = match.begin(:data)
     return false if header_end.nil?
 
-    uri[0...header_end].downcase.include?("base64")
+    uri[0...header_end].match?(/base64/i)
   end
 end

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -85,10 +85,12 @@ class ::DataUri
   end
   
   def json?
-    mimetype.include?('json') || decoded_data.lstrip.start_with?('{', '[')
+    return @_json if instance_variable_defined?(:@_json)
+    
+    @_json = mimetype.include?('json') || decoded_data.lstrip.start_with?('{', '[')
   end
   
-  def parse_json(symbolize_names: false, max_nesting: 200)
+  def parse_json(symbolize_names: false, max_nesting: 100)
     raise ArgumentError, 'not JSON' unless json?
     JSON.parse(decoded_data, symbolize_names: symbolize_names, max_nesting: max_nesting)
   end

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -1,5 +1,6 @@
 require "base64"
 require "json"
+require "uri"
 
 class ::DataUri
   REGEXP = %r{
@@ -75,7 +76,7 @@ class ::DataUri
   end
   
   def decoded_data
-    base64? ? base64_decoded_data : data
+    base64? ? base64_decoded_data : URI::DEFAULT_PARSER.unescape(data)
   end
   
   def claims_to_be_base64?

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -13,7 +13,7 @@ class ::DataUri
     (?<data>.*)
   }x.freeze
 
-  attr_reader :mimetype, :parameters, :extension, :data, :uri
+  attr_reader :mimetype, :parameters, :extension, :data, :uri, :match
 
   def initialize(uri)
     @uri = uri
@@ -25,7 +25,6 @@ class ::DataUri
     @header_contains_base64 = !!(header.match?(/base64/i))
 
     if uri.start_with?('data:,')
-      @match = nil
       @mimetype = 'text/plain'
       @parameters = []
       @extension = nil

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -1,4 +1,5 @@
 require "base64"
+require "json"
 
 class ::DataUri
   REGEXP = %r{
@@ -12,16 +13,30 @@ class ::DataUri
     (?<data>.*)
   }x.freeze
 
-  attr_reader :uri, :match
+  attr_reader :mimetype, :parameters, :extension, :data, :uri
 
   def initialize(uri)
-    match = REGEXP.match(uri)
-    raise ArgumentError, 'invalid data URI' unless match
-
     @uri = uri
-    @match = match
-    
-    validate_base64_content
+    @match = REGEXP.match(uri)
+    raise ArgumentError, 'invalid data URI' unless @match
+
+    header_end = @match.begin(:data)
+    header = header_end.nil? ? '' : uri[0...header_end]
+    @header_contains_base64 = !!(header.match?(/base64/i))
+
+    if uri.start_with?('data:,')
+      @match = nil
+      @mimetype = 'text/plain'
+      @parameters = []
+      @extension = nil
+      @data = uri.split(',', 2).last || ''
+    else
+      @mimetype = String(@match[:mimetype]).empty? ? 'text/plain' : @match[:mimetype]
+      @parameters = String(@match[:parameters]).split(';').reject(&:empty?)
+      @extension = @match[:extension]
+      @data = @match[:data]
+      validate_base64_content
+    end
   end
 
   def self.valid?(uri)
@@ -54,7 +69,7 @@ class ::DataUri
   end
 
   def base64?
-    metadata_contains_base64? && data_valid_base64?
+    @header_contains_base64 && data_valid_base64?
   end
   
   def decoded_data
@@ -65,30 +80,17 @@ class ::DataUri
     !String(extension).empty?
   end
 
-  def mimetype
-    if String(match[:mimetype]).empty? || uri.starts_with?("data:,")
-      return 'text/plain'
-    end
-    
-    match[:mimetype]
-  end
-  
-  def data
-    match[:data]
-  end
-
   def data_valid_base64?
     !base64_decoded_data.nil?
   end
-
-  def parameters
-    return [] if String(match[:mimetype]).empty? && String(match[:parameters]).empty?
-
-    match[:parameters].split(";").reject(&:empty?)
-  end  
   
-  def extension
-    match[:extension]
+  def json?
+    mimetype.include?('json') || decoded_data.lstrip.start_with?('{', '[')
+  end
+  
+  def parse_json(symbolize_names: false, max_nesting: 200)
+    raise ArgumentError, 'not JSON' unless json?
+    JSON.parse(decoded_data, symbolize_names: symbolize_names, max_nesting: max_nesting)
   end
 
   private
@@ -101,12 +103,5 @@ class ::DataUri
     rescue ArgumentError
       nil
     end
-  end
-
-  def metadata_contains_base64?
-    header_end = match.begin(:data)
-    return false if header_end.nil?
-
-    uri[0...header_end].match?(/base64/i)
   end
 end

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -53,12 +53,12 @@ class ::DataUri
     "#{mimetype}#{parameters}"
   end
 
-  def is_base64?
+  def base64?
     metadata_contains_base64? && data_valid_base64?
   end
   
   def decoded_data
-    is_base64? ? base64_decoded_data : data
+    base64? ? base64_decoded_data : data
   end
   
   def claims_to_be_base64?

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -50,9 +50,11 @@ class ::DataUri
 
   def self.esip6?(uri)
     begin
-      parameters = DataUri.new(uri).parameters
+      data_uri = DataUri.new(uri)
 
-      parameters.include?("rule=esip6")
+      # Use legacy behavior to support Ethscriptions
+      raw_parameters = String(data_uri.match[:parameters]).split(';')
+      raw_parameters.include?("rule=esip6")
     rescue ArgumentError
       false
     end

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -1,3 +1,5 @@
+require "base64"
+
 class ::DataUri
   REGEXP = %r{
     \Adata:
@@ -42,26 +44,24 @@ class ::DataUri
   end
 
   def validate_base64_content
-    if base64?
-      begin
-        Base64.strict_decode64(data)
-      rescue ArgumentError
-        raise ArgumentError, 'malformed base64 content'
-      end
-    end
+    return unless claims_to_be_base64?
+
+    raise ArgumentError, 'malformed base64 content' unless data_valid_base64?
   end
 
   def mediatype
     "#{mimetype}#{parameters}"
   end
 
-  def decoded_data
-    return data unless base64?
-
-    Base64.decode64(data)
+  def is_base64?
+    metadata_contains_base64? && data_valid_base64?
   end
   
-  def base64?
+  def decoded_data
+    is_base64? ? base64_decoded_data : data
+  end
+  
+  def claims_to_be_base64?
     !String(extension).empty?
   end
 
@@ -77,13 +77,36 @@ class ::DataUri
     match[:data]
   end
 
+  def data_valid_base64?
+    !base64_decoded_data.nil?
+  end
+
   def parameters
     return [] if String(match[:mimetype]).empty? && String(match[:parameters]).empty?
-  
+
     match[:parameters].split(";").reject(&:empty?)
   end  
   
   def extension
     match[:extension]
+  end
+
+  private
+
+  def base64_decoded_data
+    return @base64_decoded_data if instance_variable_defined?(:@base64_decoded_data)
+
+    @base64_decoded_data = begin
+      Base64.strict_decode64(data)
+    rescue ArgumentError
+      nil
+    end
+  end
+
+  def metadata_contains_base64?
+    header_end = match.begin(:data)
+    return false if header_end.nil?
+
+    uri[0...header_end].downcase.include?("base64")
   end
 end

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -65,6 +65,53 @@ class DataUriTest < Minitest::Test
     error = assert_raises(ArgumentError) { DataUri.new(uri) }
     assert_equal "malformed base64 content", error.message
   end
+
+  def test_implicit_form_with_legacy_base64_valid_decodes_and_defaults
+    uri = "data:,text/plain;charset=utf-8;base64,SGVsbG8="
+    du = DataUri.new(uri)
+
+    assert_equal "text/plain", du.mimetype
+    assert_equal [], du.parameters
+    assert_nil du.extension
+    assert_equal "Hello", du.decoded_data
+  end
+
+  def test_valid_question_mark_false_for_implicit_legacy_invalid_base64
+    uri = "data:,text/plain;charset=utf-8;base64,@@@"
+    refute DataUri.valid?(uri)
+  end
+
+  def test_uppercase_base64_param_valid_decodes
+    uri = "data:text/plain;foo=BASE64,SGVsbG8="
+    du = DataUri.new(uri)
+
+    assert du.base64?
+    assert_equal "Hello", du.decoded_data
+  end
+
+  def test_uppercase_base64_param_invalid_returns_original
+    uri = "data:text/plain;foo=BASE64,@@@"
+    du = DataUri.new(uri)
+
+    refute du.data_valid_base64?
+    refute du.base64?
+    assert_equal "@@@", du.decoded_data
+  end
+
+  def test_empty_base64_content_decodes_to_empty_string
+    uri = "data:text/plain;base64,"
+    du = DataUri.new(uri)
+
+    assert_equal "", du.decoded_data
+  end
+
+  def test_no_mimetype_with_base64_defaults_and_decodes
+    uri = "data:;base64,SGVsbG8="
+    du = DataUri.new(uri)
+
+    assert_equal "text/plain", du.mimetype
+    assert_equal "Hello", du.decoded_data
+  end
   
   def test_valid_question_mark_true_for_valid_data_uris
     assert DataUri.valid?("data:text/plain,abc")

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "facet_rails_common/data_uri"
+
+class DataUriTest < Minitest::Test
+  def test_decoded_data_with_base64_extension
+    uri = "data:text/plain;base64,SGVsbG8="
+
+    assert_equal "Hello", DataUri.new(uri).decoded_data
+  end
+
+  def test_decoded_data_when_metadata_mentions_base64
+    uri = "data:text/plain;foo=base64,SGVsbG8="
+
+    assert_equal "Hello", DataUri.new(uri).decoded_data
+  end
+
+  def test_decoded_data_when_metadata_mentions_base64_in_mime_type
+    uri = "data:application/Base64Something,SGVsbG8="
+
+    assert_equal "Hello", DataUri.new(uri).decoded_data
+  end
+
+  def test_returns_original_data_when_metadata_mentions_base64_but_data_invalid
+    uri = "data:text/plain;foo=base64,@@@"
+    data_uri = DataUri.new(uri)
+
+    refute data_uri.data_valid_base64?
+    assert_equal "@@@", data_uri.decoded_data
+  end
+
+  def test_returns_original_data_when_base64_only_in_payload
+    uri = "data:text/plain,base64SGVsbG8="
+
+    assert_equal "base64SGVsbG8=", DataUri.new(uri).decoded_data
+  end
+
+  def test_invalid_base64_with_extension_raises
+    uri = "data:text/plain;base64,@@@"
+
+    error = assert_raises(ArgumentError) { DataUri.new(uri) }
+    assert_equal "malformed base64 content", error.message
+  end
+end

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -190,4 +190,11 @@ class DataUriTest < Minitest::Test
 
     assert_equal "a b+c=d", du.decoded_data
   end
+
+  def test_decoded_data_percent_decodes_svg
+    uri = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3C%2Fsvg%3E"
+    du = DataUri.new(uri)
+
+    assert_equal '<svg xmlns="http://www.w3.org/2000/svg"></svg>', du.decoded_data
+  end
 end

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -151,4 +151,14 @@ class DataUriTest < Minitest::Test
     refute DataUri.esip6?("data:text/plain;rule=other,abc")
     refute DataUri.esip6?("not a data uri")
   end
+
+  def test_esip6_legacy_implicit_form
+    uri = 'data:,text/plain;rule=esip6,{"p":"erc-20","op":"mint","tick":"eths","amt":"1000"}'
+    assert DataUri.esip6?(uri)
+  end
+
+  def test_esip6_legacy_implicit_form_other_rule
+    uri = 'data:,text/plain;rule=other,{"p":"erc-20","op":"mint","tick":"eths","amt":"1000"}'
+    refute DataUri.esip6?(uri)
+  end
 end

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -9,6 +9,17 @@ class DataUriTest < Minitest::Test
 
     assert_equal "Hello", DataUri.new(uri).decoded_data
   end
+  
+  def test_implicit_data_uri_defaults_and_decoding
+    uri = "data:,Hello"
+    du = DataUri.new(uri)
+    assert_equal "text/plain", du.mimetype
+    assert_equal [], du.parameters
+    assert_nil du.extension
+    assert_equal "Hello", du.data
+    refute du.base64?
+    assert_equal "Hello", du.decoded_data
+  end
 
   def test_decoded_data_when_metadata_mentions_base64
     uri = "data:text/plain;foo=base64,SGVsbG8="
@@ -41,5 +52,44 @@ class DataUriTest < Minitest::Test
 
     error = assert_raises(ArgumentError) { DataUri.new(uri) }
     assert_equal "malformed base64 content", error.message
+  end
+  
+  def test_valid_question_mark_true_for_valid_data_uris
+    assert DataUri.valid?("data:text/plain,abc")
+    assert DataUri.valid?("data:,")
+    assert DataUri.valid?("data:application/json,{\"a\":1}")
+  end
+  
+  def test_valid_question_mark_false_for_non_data_uris
+    refute DataUri.valid?("http://example.com")
+    refute DataUri.valid?("data;not,a,uri")
+  end
+  
+  def test_json_helpers_by_mimetype
+    uri = "data:application/json,{\"a\":1}"
+    du = DataUri.new(uri)
+    assert du.json?
+    assert_equal({"a"=>1}, du.parse_json)
+    assert_equal({a: 1}, du.parse_json(symbolize_names: true))
+  end
+  
+  def test_json_helpers_by_payload_prefix
+    json_b64 = "eyJhIjoxfQ==" # {"a":1}
+    uri = "data:application/octet-stream;base64,#{json_b64}"
+    du = DataUri.new(uri)
+    assert du.json?
+    assert_equal({"a"=>1}, du.parse_json)
+  end
+  
+  def test_parse_json_raises_when_not_json
+    du = DataUri.new("data:text/plain,hello")
+    error = assert_raises(ArgumentError) { du.parse_json }
+    assert_equal "not JSON", error.message
+  end
+  
+  def test_esip6_param_detection
+    assert DataUri.esip6?("data:text/plain;rule=esip6,abc")
+    refute DataUri.esip6?("data:text/plain;rule=other,abc")
+    refute DataUri.esip6?("not a data uri")
   end
 end

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -58,6 +58,13 @@ class DataUriTest < Minitest::Test
     error = assert_raises(ArgumentError) { DataUri.new(uri) }
     assert_equal "malformed base64 content", error.message
   end
+
+  def test_implicit_form_with_legacy_base64_extension_raises
+    uri = "data:,text/plain;charset=utf-8;base64,8J+Msi50cmVl,"
+
+    error = assert_raises(ArgumentError) { DataUri.new(uri) }
+    assert_equal "malformed base64 content", error.message
+  end
   
   def test_valid_question_mark_true_for_valid_data_uris
     assert DataUri.valid?("data:text/plain,abc")

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -161,4 +161,33 @@ class DataUriTest < Minitest::Test
     uri = 'data:,text/plain;rule=other,{"p":"erc-20","op":"mint","tick":"eths","amt":"1000"}'
     refute DataUri.esip6?(uri)
   end
+
+  def test_decoded_data_percent_decodes_space
+    uri = "data:text/plain,Hello%20World"
+    du = DataUri.new(uri)
+
+    assert_equal "Hello%20World", du.data
+    assert_equal "Hello World", du.decoded_data
+  end
+
+  def test_decoded_data_preserves_plus_sign
+    uri = "data:text/plain,Hello+World"
+    du = DataUri.new(uri)
+
+    assert_equal "Hello+World", du.decoded_data
+  end
+
+  def test_decoded_data_percent_decodes_html
+    uri = "data:text/html,%3Ch1%3EHello%3C%2Fh1%3E"
+    du = DataUri.new(uri)
+
+    assert_equal "<h1>Hello</h1>", du.decoded_data
+  end
+
+  def test_decoded_data_percent_decodes_mixed_content
+    uri = "data:text/plain,a%20b+c%3Dd"
+    du = DataUri.new(uri)
+
+    assert_equal "a b+c=d", du.decoded_data
+  end
 end

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -10,6 +10,11 @@ class DataUriTest < Minitest::Test
     assert_equal "Hello", DataUri.new(uri).decoded_data
   end
   
+  def test_implicit_data_uri_keeps_commas_after_first_split
+    du = DataUri.new("data:,hi/bye,yo")
+    assert_equal "hi/bye,yo", du.data
+  end
+  
   def test_implicit_data_uri_defaults_and_decoding
     uri = "data:,Hello"
     du = DataUri.new(uri)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances `DataUri` to recognize more base64 forms, percent-decode non-base64 payloads, support implicit `data:,` URIs, add JSON parsing helpers, and update ESIP6 detection with extensive tests.
> 
> - **Core (`lib/facet_rails_common/data_uri.rb`)**:
>   - **Base64 handling**: Detects `base64` anywhere in the header (case-insensitive); validates only when `;base64` extension is present; memoized strict decoding; `base64?`, `claims_to_be_base64?`, and `data_valid_base64?` added.
>   - **Decoding**: Returns base64-decoded data when valid; otherwise percent-decodes via `URI::DEFAULT_PARSER.unescape` (preserves `+`).
>   - **Implicit form support**: For `data:,...` defaults `mimetype` to `text/plain`, clears parameters/extension, and keeps data after the first comma intact.
>   - **API additions**: Exposes `mimetype`, `parameters` (as array), `extension`, `data`; adds `json?` and `parse_json` helpers.
>   - **ESIP6 detection**: `esip6?` reads raw parameters from the match to support legacy implicit forms.
> - **Tests (`test/data_uri_test.rb`)**:
>   - Comprehensive coverage for base64 variants (extension, params, MIME, case), invalid/empty payloads, implicit form, `valid?`, JSON helpers, ESIP6 legacy detection, and percent-decoding (spaces, HTML, SVG, plus sign).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5adc786d37042a30418b1c50939e910138f21034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->