### PR TITLE
Enhance DataUri class to support implicit data URIs and JSON parsing

### DIFF
--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -85,10 +85,12 @@ class ::DataUri
   end
   
   def json?
-    mimetype.include?('json') || decoded_data.lstrip.start_with?('{', '[')
+    return @_json if instance_variable_defined?(:@_json)
+    
+    @_json = mimetype.include?('json') || decoded_data.lstrip.start_with?('{', '[')
   end
   
-  def parse_json(symbolize_names: false, max_nesting: 200)
+  def parse_json(symbolize_names: false, max_nesting: 100)
     raise ArgumentError, 'not JSON' unless json?
     JSON.parse(decoded_data, symbolize_names: symbolize_names, max_nesting: max_nesting)
   end

--- a/lib/facet_rails_common/data_uri.rb
+++ b/lib/facet_rails_common/data_uri.rb
@@ -1,4 +1,5 @@
 require "base64"
+require "json"
 
 class ::DataUri
   REGEXP = %r{
@@ -12,16 +13,30 @@ class ::DataUri
     (?<data>.*)
   }x.freeze
 
-  attr_reader :uri, :match
+  attr_reader :mimetype, :parameters, :extension, :data, :uri
 
   def initialize(uri)
-    match = REGEXP.match(uri)
-    raise ArgumentError, 'invalid data URI' unless match
-
     @uri = uri
-    @match = match
-    
-    validate_base64_content
+    @match = REGEXP.match(uri)
+    raise ArgumentError, 'invalid data URI' unless @match
+
+    header_end = @match.begin(:data)
+    header = header_end.nil? ? '' : uri[0...header_end]
+    @header_contains_base64 = !!(header.match?(/base64/i))
+
+    if uri.start_with?('data:,')
+      @match = nil
+      @mimetype = 'text/plain'
+      @parameters = []
+      @extension = nil
+      @data = uri.split(',', 2).last || ''
+    else
+      @mimetype = String(@match[:mimetype]).empty? ? 'text/plain' : @match[:mimetype]
+      @parameters = String(@match[:parameters]).split(';').reject(&:empty?)
+      @extension = @match[:extension]
+      @data = @match[:data]
+      validate_base64_content
+    end
   end
 
   def self.valid?(uri)
@@ -54,7 +69,7 @@ class ::DataUri
   end
 
   def base64?
-    metadata_contains_base64? && data_valid_base64?
+    @header_contains_base64 && data_valid_base64?
   end
   
   def decoded_data
@@ -65,30 +80,17 @@ class ::DataUri
     !String(extension).empty?
   end
 
-  def mimetype
-    if String(match[:mimetype]).empty? || uri.starts_with?("data:,")
-      return 'text/plain'
-    end
-    
-    match[:mimetype]
-  end
-  
-  def data
-    match[:data]
-  end
-
   def data_valid_base64?
     !base64_decoded_data.nil?
   end
-
-  def parameters
-    return [] if String(match[:mimetype]).empty? && String(match[:parameters]).empty?
-
-    match[:parameters].split(";").reject(&:empty?)
-  end  
   
-  def extension
-    match[:extension]
+  def json?
+    mimetype.include?('json') || decoded_data.lstrip.start_with?('{', '[')
+  end
+  
+  def parse_json(symbolize_names: false, max_nesting: 200)
+    raise ArgumentError, 'not JSON' unless json?
+    JSON.parse(decoded_data, symbolize_names: symbolize_names, max_nesting: max_nesting)
   end
 
   private
@@ -101,12 +103,5 @@ class ::DataUri
     rescue ArgumentError
       nil
     end
-  end
-
-  def metadata_contains_base64?
-    header_end = match.begin(:data)
-    return false if header_end.nil?
-
-    uri[0...header_end].match?(/base64/i)
   end
 end

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -9,6 +9,17 @@ class DataUriTest < Minitest::Test
 
     assert_equal "Hello", DataUri.new(uri).decoded_data
   end
+  
+  def test_implicit_data_uri_defaults_and_decoding
+    uri = "data:,Hello"
+    du = DataUri.new(uri)
+    assert_equal "text/plain", du.mimetype
+    assert_equal [], du.parameters
+    assert_nil du.extension
+    assert_equal "Hello", du.data
+    refute du.base64?
+    assert_equal "Hello", du.decoded_data
+  end
 
   def test_decoded_data_when_metadata_mentions_base64
     uri = "data:text/plain;foo=base64,SGVsbG8="
@@ -41,5 +52,44 @@ class DataUriTest < Minitest::Test
 
     error = assert_raises(ArgumentError) { DataUri.new(uri) }
     assert_equal "malformed base64 content", error.message
+  end
+  
+  def test_valid_question_mark_true_for_valid_data_uris
+    assert DataUri.valid?("data:text/plain,abc")
+    assert DataUri.valid?("data:,")
+    assert DataUri.valid?("data:application/json,{\"a\":1}")
+  end
+  
+  def test_valid_question_mark_false_for_non_data_uris
+    refute DataUri.valid?("http://example.com")
+    refute DataUri.valid?("data;not,a,uri")
+  end
+  
+  def test_json_helpers_by_mimetype
+    uri = "data:application/json,{\"a\":1}"
+    du = DataUri.new(uri)
+    assert du.json?
+    assert_equal({"a"=>1}, du.parse_json)
+    assert_equal({a: 1}, du.parse_json(symbolize_names: true))
+  end
+  
+  def test_json_helpers_by_payload_prefix
+    json_b64 = "eyJhIjoxfQ==" # {"a":1}
+    uri = "data:application/octet-stream;base64,#{json_b64}"
+    du = DataUri.new(uri)
+    assert du.json?
+    assert_equal({"a"=>1}, du.parse_json)
+  end
+  
+  def test_parse_json_raises_when_not_json
+    du = DataUri.new("data:text/plain,hello")
+    error = assert_raises(ArgumentError) { du.parse_json }
+    assert_equal "not JSON", error.message
+  end
+  
+  def test_esip6_param_detection
+    assert DataUri.esip6?("data:text/plain;rule=esip6,abc")
+    refute DataUri.esip6?("data:text/plain;rule=other,abc")
+    refute DataUri.esip6?("not a data uri")
   end
 end

--- a/test/data_uri_test.rb
+++ b/test/data_uri_test.rb
@@ -10,6 +10,11 @@ class DataUriTest < Minitest::Test
     assert_equal "Hello", DataUri.new(uri).decoded_data
   end
   
+  def test_implicit_data_uri_keeps_commas_after_first_split
+    du = DataUri.new("data:,hi/bye,yo")
+    assert_equal "hi/bye,yo", du.data
+  end
+  
   def test_implicit_data_uri_defaults_and_decoding
     uri = "data:,Hello"
     du = DataUri.new(uri)


### PR DESCRIPTION
- Added handling for implicit data URIs, defaulting mimetype to 'text/plain'.
- Introduced methods for JSON detection and parsing.
- Updated tests to cover new functionality and validate behavior for various data URIs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds implicit `data:,` handling with sensible defaults, JSON detection/parsing, base64 detection tweaks, and helper predicates, with tests covering new behavior.
> 
> - **DataUri**:
>   - Handle implicit `data:,` URIs with defaults (`mimetype`=`text/plain`, empty `parameters`, no `extension`); preserve commas after first split.
>   - Refactor parsing/expose readers (`mimetype`, `parameters`, `extension`, `data`, `uri`); base64 detection via header scan; validate malformed base64 only when `;base64` present.
>   - Add JSON utilities: `json?` and `parse_json(symbolize_names:, max_nesting:)` (auto-detect by mimetype or payload prefix).
>   - Add class helpers: `valid?(uri)` and `esip6?(uri)`.
> - **Tests**:
>   - New/updated tests covering implicit URIs, base64 behaviors, validity checks, JSON parsing, and `esip6?` detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14a2bfb30b80d37682de3723a1c04816b8879226. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->